### PR TITLE
Fix turnOnPreview(x,y,w,h)

### DIFF
--- a/src/com/hopding/jrpicam/RPiCamera.java
+++ b/src/com/hopding/jrpicam/RPiCamera.java
@@ -646,7 +646,7 @@ public class RPiCamera {
 	 * @param h An int specifying height of preview window.
 	 */
 	public void turnOnPreview(int x, int y, int w, int h) {
-		options.put("preview", new String[] { "-p", "" + x, ",", "" + y, ",", "" + w, ",", "" + h });
+		options.put("preview", new String[] { "-p", "" + x + "," + y + "," + w + "," + h });
 	}
 	
 	/**


### PR DESCRIPTION
Fails with the following message otherwise:
Invalid command line option (,)
